### PR TITLE
feat: support audit via HTTPS proxy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export default class ProxyAudit {
         {
           url: 'https://registry.npmjs.org/-/npm/v1/security/audits',
           method: 'POST',
+          proxy: auth.config.https_proxy,
           req,
           body: JSON.stringify(req.body),
           gzip: true,


### PR DESCRIPTION
Tested both with and without `https_proxy` config in both intranet and internet environment respectively.

Close https://github.com/verdaccio/verdaccio-audit/issues/2