### PR TITLE
fix: pipe request and response bodies to save memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   "author": "Juan Picado <juanpicado19@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "body-parser": "1.18.3",
-    "compression": "1.7.3",
     "express": "4.16.3",
     "request": "2.87.0"
   },


### PR DESCRIPTION
I have refactored the code to pipe the incoming request to the NPM registry and pipe the response from NPM back to the client. This will reduce memory usage, make the implementation less fragile if the content-type that NPM sends changes, and reduce the number of dependencies for the project.

I'm away for a week and a bit now but if you have any comments I'll look at them when I get back.

Given that this module is shipped with `verdaccio` and enabled by default for new installs I think we need to have some proper tests, preferably doing real NPM calls through `verdaccio` using this plugin.  I'll maybe look into that when I get back.