### PR TITLE
fix: bad network causes the server down & types error

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -19,7 +19,7 @@ export default class ProxyAudit extends Plugin<ConfigAudit> implements IPluginMi
   }
 
   register_middlewares(app: any, auth: IBasicAuth<ConfigAudit>, storage: IStorageManager<ConfigAudit>) {
-    const fetchAudit = (req: Request, res: Response) => {
+    const fetchAudit = (req: Request, res: Response & { report_error?: Function }) => {
       const headers = req.headers;
       headers.host = 'https://registry.npmjs.org/';
 
@@ -31,7 +31,14 @@ export default class ProxyAudit extends Plugin<ConfigAudit> implements IPluginMi
         strictSSL: true
       };
 
-      req.pipe(request(requestOptions)).pipe(res);
+      req.pipe(request(requestOptions))
+        .on('error', err => {
+          if (typeof res.report_error === 'function')
+            return res.report_error(err);
+          this.logger.error(err);
+          return res.status(500).end();
+        })
+        .pipe(res);
     };
 
     const handleAudit = (req: Request, res: Response) => {

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,6 +1,7 @@
 import express, {Request, Response} from 'express';
 import request from 'request';
-import { Logger, IPluginMiddleware, IBasicAuth, IStorageManager, PluginOptions, Plugin } from '@verdaccio/types';
+import { Logger, IPluginMiddleware, IBasicAuth, IStorageManager, PluginOptions } from '@verdaccio/types';
+import { Plugin } from './types';
 
 export type ConfigAudit = {
   enabled: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+// Temporary solution for requiring types will not cause the error.
+import { PluginOptions } from "@verdaccio/types";
+export class Plugin<T> {
+	constructor(config: T, options: PluginOptions<T>) { }
+}


### PR DESCRIPTION
Because it requests the audit information via stream and the listener for the error event is missing. So an uncaught exception will be caused and make server down if there any network error appeared. For example:

![Screenshot from 2019-03-20 16-10-38](https://user-images.githubusercontent.com/4303130/54669130-8d6e3e00-4b2b-11e9-8947-419573bae1ff.png)
