### PR TITLE
fix:  audit module doesn't support strict_ssl flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,16 @@
 
 ## Usage
 To enable it you need to add this to your configuration file.
-```
+```yaml
 middlewares:
   audit:
     enabled: true
+    strict_ssl: true # optional, defaults to true
 ```
+
+### Strict SSL
+
+In some scenarios it may be necessary to disable SSL certificate validation. Setting *strict_ssl* to false will disable these checks, but will make all connections passing through this plugin inherently insecure.
 
 ## Disclaimer
 

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -7,9 +7,11 @@ import { ConfigAudit } from './types';
 export default class ProxyAudit implements IPluginMiddleware<ConfigAudit> {
   enabled: boolean;
   logger: Logger;
+  strict_ssl: boolean;
 
   constructor(config: ConfigAudit, options: PluginOptions<ConfigAudit>) {
     this.enabled = config.enabled || false;
+    this.strict_ssl = config.strict_ssl !== undefined ? config.strict_ssl : true;
     this.logger = options.logger;
   }
 
@@ -23,7 +25,7 @@ export default class ProxyAudit implements IPluginMiddleware<ConfigAudit> {
         method: req.method,
         proxy: auth.config.https_proxy,
         req,
-        strictSSL: true
+        strictSSL: this.strict_ssl
       };
 
       req

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,5 @@ import { Config } from '@verdaccio/types';
 
 export interface ConfigAudit extends Config {
   enabled: boolean;
+  strict_ssl?: boolean | void;
 }

--- a/tests/audit.spec.ts
+++ b/tests/audit.spec.ts
@@ -23,4 +23,12 @@ describe('Audit plugin', () => {
     const audit = new ProxyAudit(config, { logger, config: undefined });
     expect(audit).toBeDefined();
   });
+
+  test('should test audit with configuration', () => {
+    // @ts-ignore
+    const config: ConfigAudit = { strict_ssl: false };
+    const audit = new ProxyAudit(config, { logger, config: config });
+    expect(audit).toBeDefined();
+    expect(audit.strict_ssl).toBeFalsy();
+  });
 });


### PR DESCRIPTION
Add support for strict_ssl as discussed in [1293](https://github.com/verdaccio/verdaccio/issues/1293)